### PR TITLE
Remove the -XX:+CMSIncrementalPacing option to Java

### DIFF
--- a/msm.conf
+++ b/msm.conf
@@ -162,7 +162,7 @@ DEFAULT_RAM="1024"
 #
 # Hard coding values here (not using {MEMORY} and {JAR} tags) will prevent
 # servers from individually overriding those values.
-DEFAULT_INVOCATION="java -Xms{RAM}M -Xmx{RAM}M -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalPacing -XX:+AggressiveOpts -jar {JAR} nogui"
+DEFAULT_INVOCATION="java -Xms{RAM}M -Xmx{RAM}M -XX:+UseConcMarkSweepGC  -XX:+AggressiveOpts -jar {JAR} nogui"
 
 
 # The default time to delay between warning players the server is stopping and


### PR DESCRIPTION
CMSIncrementalPacing is stopping msm from launching servers on Java 10. This is particularly problematic on Ubuntu 18.04 systems running OpenJDK 10.0.1 2018-04-17.
